### PR TITLE
Fix broken URL to working location

### DIFF
--- a/slide1.php
+++ b/slide1.php
@@ -1,5 +1,5 @@
 <h2 id="slide1">Demo 1 - Sliding by adding padding (transitions)</h2>
-<p>For more information on these, check this updated post: <a href="/blog/2010/08/howto/an-animated-image-slider-that-works-in-internet-explorer/">cross browser implementation</a>.
+<p>For more information on these, check this updated post: <a href="http://focalstrategy.com/blog/2010/08/howto/an-animated-image-slider-that-works-in-internet-explorer/">cross browser implementation</a>.
 <h3>Plan</h3>
 <ol>
 	<li>Create a container with overflow set to hidden.</li>


### PR DESCRIPTION
Noticed that link ("check this updated post: cross browser implementation") from http://css3.bradshawenterprises.com/sliding/ page was pointing to broken location. Searched for it and found new URL.

Hopefully this helps.
